### PR TITLE
Updated regex to support 2.5Gbit

### DIFF
--- a/opnsense_checkmk_agent.py
+++ b/opnsense_checkmk_agent.py
@@ -465,7 +465,7 @@ class checkmk_checker(object):
                     ## 0x800 SIMPLEX
                     ## 0x8000 MULTICAST
                 if _key == "media":
-                    _match = re.search("\((?P<speed>\d+G?)base(?:.*?<(?P<duplex>.*?)>)?",_val)
+                    _match = re.search("\((?P<speed>\d+G?)(?i)base(-{0,1})(?:.*?<(?P<duplex>.*?)>)?",_val)
                     if _match:
                         _interface_dict["speed"] = _match.group("speed").replace("G","000")
                         _interface_dict["duplex"] = _match.group("duplex")


### PR DESCRIPTION
Not sure why the difference, but this change catches both
```
media: Ethernet autoselect (1000baseT <full-duplex>)
media: Ethernet autoselect (2500Base-T <full-duplex>)
```