### PR TITLE
Support double or more digit interfaces

### DIFF
--- a/opnsense_checkmk_agent.py
+++ b/opnsense_checkmk_agent.py
@@ -449,7 +449,7 @@ class checkmk_checker(object):
             _interface_dict["systime"] = _now
             for _key, _val in re.findall("^\s*(\w+)[:\s=]+(.*?)$",_data,re.MULTILINE):
                 if _key == "description":
-                   _interface_dict["interface_name"] = re.sub("_\((lan|wan|opt\d)\)","",_val.strip().replace(" ","_"))
+                   _interface_dict["interface_name"] = re.sub("_\((lan|wan|opt\d+)\)","",_val.strip().replace(" ","_"))
                 if _key == "groups":
                     _interface_dict["groups"] = _val.strip().split()
                 if _key == "ether":


### PR DESCRIPTION
Currently the regex only supports single digit interface numbers, for example if you have opt10 or even opt22, the logic will not clean up the interface name correctly, as it does not match the regex expression. Adding the + to look for one or more occurrences of a digit fixes the issue.

Before: Interface DMZ_(opt11)
After: Interface modem